### PR TITLE
IUCN cat 0 implementation

### DIFF
--- a/NatureArea.py
+++ b/NatureArea.py
@@ -148,9 +148,11 @@ class NatureArea(WikidataItem):
         """
         Set the IUCN category of the area.
 
+        If the IUCN category is 0 (not applicable),
+        use 'novalue' as the value.
+
         :return: nothing
         """
-        print(self.raw_data["NAMN"])
         raw_status = self.raw_data["IUCNKAT"]
         iucn_type = raw_status.split(',')[0]
         if iucn_type == "0":

--- a/NatureArea.py
+++ b/NatureArea.py
@@ -150,13 +150,16 @@ class NatureArea(WikidataItem):
 
         :return: nothing
         """
+        print(self.raw_data["NAMN"])
         raw_status = self.raw_data["IUCNKAT"]
         iucn_type = raw_status.split(',')[0]
-        raw_timestamp = self.raw_data["URSBESLDAT"][1:11]
-        status_item = self.iucn.get(iucn_type)
-        qualifier = self.make_qualifier_startdate(raw_timestamp)
-        self.add_statement("iucn", status_item, quals=qualifier)
-        #  To do: add no_value https://phabricator.wikimedia.org/T165845
+        if iucn_type == "0":
+            self.add_statement("iucn", "novalue")
+        else:
+            raw_timestamp = self.raw_data["URSBESLDAT"][1:11]
+            status_item = self.iucn.get(iucn_type)
+            qualifier = self.make_qualifier_startdate(raw_timestamp)
+            self.add_statement("iucn", status_item, quals=qualifier)
 
     def set_is(self):
         """

--- a/WikidataItem.py
+++ b/WikidataItem.py
@@ -83,6 +83,8 @@ class WikidataItem(object):
             value = value[0]
         if utils.string_is_q_item(value):
             val_item = self.make_q_item(value)
+        elif value == "novalue":
+            val_item = value
         elif isinstance(value, dict) and 'quantity_value' in value:
             number = value['quantity_value']
             if 'unit' in value:
@@ -108,12 +110,19 @@ class WikidataItem(object):
         """
         Create a Wikidatastuff statement.
 
+        Supports the special data types 'somevalue'
+        and 'novalue'.
+
         :prop value: the content of the statement
         :prop value: Expected type: pywikibot item
 
         :return: a wikidatastuff statement
         """
-        return self.wdstuff.Statement(value)
+        if value in ['somevalue', 'novalue']:
+            special = True
+        else:
+            special = False
+        return self.wdstuff.Statement(value, special=special)
 
     def make_qualifier_applies_to(self, value):
         """


### PR DESCRIPTION
For nature reserves with the IUCN category 0, use the special datatype `novalue` for [P814](https://www.wikidata.org/wiki/Property:P814).

[Example of it being used.](https://www.wikidata.org/w/index.php?title=Q4115189&oldid=487840205)

Task: https://phabricator.wikimedia.org/T165845