### PR TITLE
Use inception instead of start date qual

### DIFF
--- a/NatureArea.py
+++ b/NatureArea.py
@@ -146,8 +146,8 @@ class NatureArea(WikidataItem):
         self.add_statement("country", sweden)
 
     def set_inception(self):
+        """Set the inception date of nature area."""
         raw_timestamp = self.raw_data["URSBESLDAT"][1:11]
-        print(raw_timestamp)
         incept = utils.date_to_dict(raw_timestamp, "%Y-%m-%d")
         incept_pwb = self.make_pywikibot_item({"date_value": incept})
         self.add_statement("inception", incept_pwb)

--- a/NatureArea.py
+++ b/NatureArea.py
@@ -43,6 +43,7 @@ class NatureArea(WikidataItem):
         self.set_natur_id()
         self.set_iucn_status()
         self.set_area()
+        self.set_inception()
 
     def generate_ref_url(self):
         """
@@ -144,6 +145,13 @@ class NatureArea(WikidataItem):
         sweden = self.items["sweden"]
         self.add_statement("country", sweden)
 
+    def set_inception(self):
+        raw_timestamp = self.raw_data["URSBESLDAT"][1:11]
+        print(raw_timestamp)
+        incept = utils.date_to_dict(raw_timestamp, "%Y-%m-%d")
+        incept_pwb = self.make_pywikibot_item({"date_value": incept})
+        self.add_statement("inception", incept_pwb)
+
     def set_iucn_status(self):
         """
         Set the IUCN category of the area.
@@ -152,11 +160,8 @@ class NatureArea(WikidataItem):
         """
         raw_status = self.raw_data["IUCNKAT"]
         iucn_type = raw_status.split(',')[0]
-        raw_timestamp = self.raw_data["URSBESLDAT"][1:11]
         status_item = self.iucn.get(iucn_type)
-        qualifier = self.make_qualifier_startdate(raw_timestamp)
-        self.add_statement("iucn", status_item, quals=qualifier)
-        #  To do: add no_value https://phabricator.wikimedia.org/T165845
+        self.add_statement("iucn", status_item)
 
     def set_is(self):
         """

--- a/WikidataItem.py
+++ b/WikidataItem.py
@@ -128,20 +128,6 @@ class WikidataItem(object):
         target_item = self.wdstuff.QtoItemPage(value)
         return self.wdstuff.Qualifier(prop_item, target_item)
 
-    def make_qualifier_startdate(self, value):
-        """
-        Create a qualifier to a statement with type 'start date'.
-
-        :param value: date in the format "1999-09-31"
-        :param value: Expected type: string
-
-        :return: a wikidatastuff Qualifier
-        """
-        prop_item = self.props["start_time"]
-        value_dic = utils.date_to_dict(value, "%Y-%m-%d")
-        value_pwb = self.make_pywikibot_item({"date_value": value_dic})
-        return self.wdstuff.Qualifier(prop_item, value_pwb)
-
     def add_statement(self, prop_name, value, quals=None, ref=None):
         """
         Add a statement to the data object.

--- a/data/properties.json
+++ b/data/properties.json
@@ -8,6 +8,7 @@
     "image": "P18",
     "is": "P31",
     "iucn": "P814",
+    "inception" : "P571",
     "located_adm": "P131",
     "location": "P276",
     "nature_id": "P3613",


### PR DESCRIPTION
Right now, the timestamp extracted from BESLSTATUS in the source data is used as a start date qualifier to the IUCN status. This gets weird when the area does not have an IUCN status, as you'd have to add a timestamp to no value.

Implement Inception to all items instead.

Task: https://phabricator.wikimedia.org/T165948