### PR TITLE
Docstring cleanup

### DIFF
--- a/NatureArea.py
+++ b/NatureArea.py
@@ -17,15 +17,13 @@ class NatureArea(WikidataItem):
         Initialize the NatureArea object.
 
         :param raw_data: Row from csv file.
-        :param raw_data: Expected type: string
+        :type raw_data: string
         :param repository: Wikidata site instance.
-        :param repository: Expected type: site instance
+        :type repository: site instance
         :param data_files: Dict of various mapping files.
-        :param data_files: Expected type: dictionary
+        :type data_files: dictionary
         :param existing: WD items that already have an unique id
-        :param existing: Expected type: dictionary
-
-        :return: nothing
+        :type existing: dictionary
         """
         WikidataItem.__init__(self, raw_data, repository, data_files, existing)
         self.municipalities = data_files["municipalities"]
@@ -61,8 +59,6 @@ class NatureArea(WikidataItem):
         Publication date = included in the metadata files
                            supplied by Naturvårdsverket.
         Retrieval date =   when the stuff was downloaded to the WMSE machine.
-
-        :return: nothing
         """
         self.sources = {}
         item_nr = self.items["source_nr"]
@@ -86,8 +82,6 @@ class NatureArea(WikidataItem):
         added only in Swedish. Otherwise, if it's a pure
         geographical name, it is added in a number of Latin script
         languages.
-
-        :return: nothing
         """
         swedish_name = self.raw_data["NAMN"]
         exclude_words = ["nationalpark", "reservat", "skärgård"]
@@ -107,8 +101,6 @@ class NatureArea(WikidataItem):
 
         National park format: "national park in Sweden".
         Reserve format: "nature reserve in <län>, Sweden".
-
-        :return: nothing
         """
         if self.raw_data["SKYDDSTYP"] == "Nationalpark":
             np_dictionary = self.glossary["np_description"]
@@ -136,20 +128,12 @@ class NatureArea(WikidataItem):
                 self.add_description(language, description)
 
     def set_country(self):
-        """
-        Set the country to Sweden.
-
-        :return: nothing
-        """
+        """Set the country to Sweden."""
         sweden = self.items["sweden"]
         self.add_statement("country", sweden)
 
     def set_iucn_status(self):
-        """
-        Set the IUCN category of the area.
-
-        :return: nothing
-        """
+        """Set the IUCN category of the area."""
         raw_status = self.raw_data["IUCNKAT"]
         iucn_type = raw_status.split(',')[0]
         raw_timestamp = self.raw_data["URSBESLDAT"][1:11]
@@ -159,11 +143,7 @@ class NatureArea(WikidataItem):
         #  To do: add no_value https://phabricator.wikimedia.org/T165845
 
     def set_is(self):
-        """
-        Set the P31 property - nature reserve or national park.
-
-        :return: nothing
-        """
+        """Set the P31 property - nature reserve or national park."""
         skyddstyp = self.raw_data["SKYDDSTYP"]
         if skyddstyp == "Nationalpark":
             status = self.items["national_park"]
@@ -177,8 +157,6 @@ class NatureArea(WikidataItem):
 
         Can be more than one claim if the area stretches across
         several municipalities.
-
-        :return: nothing
         """
         municipalities_raw = self.raw_data["KOMMUN"].split(",")
         for municipality in municipalities_raw:
@@ -195,20 +173,12 @@ class NatureArea(WikidataItem):
             self.add_statement("located_adm", m_item[0])
 
     def set_natur_id(self):
-        """
-        Set the Naturvårdsverket ID number.
-
-        :return: nothing
-        """
+        """Set the Naturvårdsverket ID number."""
         nid = self.raw_data["NVRID"]
         self.add_statement("nature_id", nid)
 
     def set_forvaltare(self):
-        """
-        Set the operator of the area.
-
-        :return: nothing
-        """
+        """Set the operator of the area."""
         forvaltare = None
         forvaltare_raw = self.raw_data["FORVALTARE"]
         if forvaltare_raw == "Hässelholms kommun":
@@ -238,8 +208,6 @@ class NatureArea(WikidataItem):
         We add both: first the total area without any
         qualifiers, and then separately for every part,
         with "applies to part" qualifier.
-
-        :return: nothing
         """
         hectare = self.items["hectare"]
         area_total = self.raw_data["AREA_HA"]
@@ -264,7 +232,7 @@ class NatureArea(WikidataItem):
         Get WD item associated with certain value of unique ID.
 
         :param value: the ID to check
-        :param value: Expected type: string
+        :type value: string
 
         :return: a match, if found
         """
@@ -281,9 +249,7 @@ class NatureArea(WikidataItem):
         TODO: check the P31 of matched reserve item.
 
         :param data_files: the library of files with area Wikidata mappings
-        :param data_files: Expected type: dictionary
-
-        :return: nothing
+        :type data_files: dictionary
         """
         if self.raw_data["SKYDDSTYP"] == "Nationalpark":
             mapping = data_files["mapping_nationalparks"]
@@ -306,14 +272,14 @@ class NatureArea(WikidataItem):
         Overwrite plain add_statement with default sources.
 
         :param prop_name: P-item representing property
-        :param prop_name: Expected type: string
+        :type prop_name: string
         :param value: content of the statement
-        :param value: Expected type: it can be a string representing
+        :type value: it can be a string representing
                       a Q-item or a dictionary of an amount
         :param quals: possibly qualifier items
-        :param quals: Expected type: list of wikidatastuff Qualifier items
+        :type quals: list of wikidatastuff Qualifier items
         :param ref: reference item
-        :param ref: Expected type: a wikidatastuff Reference item
+        :type ref: a wikidatastuff Reference item
 
         :return: an add_statement function with the correct source set
                  as default depending on the type of the area.

--- a/PreviewTable.py
+++ b/PreviewTable.py
@@ -106,7 +106,7 @@ class PreviewTable(object):
         Initialize the Preview Table object.
 
         :param WD_object: data object to be represented
-        :param WD_object: Expected type: WikidataItem object
+        :type WD_object: WikidataItem object
         """
         self.wd_item = WD_object.wd_item
         self.raw_data = WD_object.raw_data

--- a/WikidataItem.py
+++ b/WikidataItem.py
@@ -30,15 +30,13 @@ class WikidataItem(object):
         Initialize the data object.
 
         :param db_row_dict: raw data from the data source
-        :param db_row_dict: Expected type: string
+        :type db_row_dict: string
         :param repository: data repository (Wikidata site)
-        :param repository: Expected type: site instance
+        :type repository: site instance
         :param data_files: dict of various mapping files
-        :param data_files: Expected type: dictionary
+        :type data_files: dictionary
         :param existing: WD items that already have an unique id
-        :param existing: Expected type: dictionary
-
-        :return: nothing
+        :type existing: dictionary
         """
         self.repo = repository
         self.existing = existing
@@ -55,7 +53,7 @@ class WikidataItem(object):
         Create a regular Wikidata ItemPage.
 
         :param qnumber: Q-item that we want to get an ItemPage of
-        :param qnumber: Expected type: string
+        :type qnumber: string
 
         :return: an ItemPage for pywikibot
         """
@@ -71,7 +69,7 @@ class WikidataItem(object):
         * an amount with or without unit (value is dic)
 
         :param value: the content of the item
-        :param value: Expected type: it can be a string or
+        :type value: it can be a string or
                       a dictionary, see above.
 
         :return: a pywikibot item of the type determined
@@ -109,7 +107,7 @@ class WikidataItem(object):
         Create a Wikidatastuff statement.
 
         :prop value: the content of the statement
-        :prop value: Expected type: pywikibot item
+        :type value: pywikibot item
 
         :return: a wikidatastuff statement
         """
@@ -120,7 +118,7 @@ class WikidataItem(object):
         Create a qualifier to a statement with type 'applies to part'.
 
         :param value: Q-item that this applies to
-        :param value: Expected type: string
+        :type value: string
 
         :return: a wikidatastuff Qualifier
         """
@@ -133,7 +131,7 @@ class WikidataItem(object):
         Create a qualifier to a statement with type 'start date'.
 
         :param value: date in the format "1999-09-31"
-        :param value: Expected type: string
+        :type value: string
 
         :return: a wikidatastuff Qualifier
         """
@@ -147,17 +145,15 @@ class WikidataItem(object):
         Add a statement to the data object.
 
         :param prop_name: P-item representing property
-        :param prop_name: Expected type: string
+        :type prop_name: string
         :param value: content of the statement
-        :param value: Expected type: it can be a string representing
+        :type value: it can be a string representing
                       a Q-item or a dictionary of an amount
         :param quals: possibly qualifier items
-        :param quals: Expected type: a wikidatastuff Qualifier item,
+        :type quals: a wikidatastuff Qualifier item,
                       or a list of them
         :param ref: reference item
-        :param ref: Expected type: a wikidatastuff Reference item
-
-        :return: nothing
+        :type ref: a wikidatastuff Reference item
         """
         base = self.wd_item["statements"]
         prop = self.props[prop_name]
@@ -180,13 +176,13 @@ class WikidataItem(object):
         Make a reference object of type 'stated in'.
 
         :param value: Q-item where sth is stated
-        :param value: Expected type: string
+        :type value: string
         :param pub_date: timestamp in format "1999-09-31"
-        :param pub_date: Expected type: string
+        :type pub_date: string
         :param ref_url: optionally a reference url
-        :param ref_url: Expected type: string
+        :type ref_url: string
         :param retrieved_date: timestamp in format "1999-09-31"
-        :param retrieved_date: Expected type: string
+        :type retrieved_date: string
 
         :return: a wikidatastuff Reference item
         """
@@ -227,9 +223,7 @@ class WikidataItem(object):
 
         :param wd_item: Q-item that shall be assigned to the
                         data object.
-        :param wd_item: Expected type: string
-
-        :return: nothing
+        :type wd_item: string
         """
         if wd_item is not None:
             self.wd_item["wd-item"] = wd_item
@@ -240,11 +234,9 @@ class WikidataItem(object):
         Add a label in a specific language.
 
         :param language: code of language, e.g. "fi"
-        :param language: Expected type: string
+        :type language: string
         :param text: content of the label
-        :param text: Expected type: string
-
-        :return: nothing
+        :type text: string
         """
         base = self.wd_item["labels"]
         base.append({"language": language, "value": text})
@@ -254,11 +246,9 @@ class WikidataItem(object):
         Add a description in a specific language.
 
         :param language: code of language, e.g. "fi"
-        :param language: Expected type: string
+        :type language: string
         :param text: content of the description
-        :param text: Expected type: string
-
-        :return: nothing
+        :type text: string
         """
         base = self.wd_item["descriptions"]
         base.append({"language": language, "value": text})
@@ -269,8 +259,6 @@ class WikidataItem(object):
 
         This creates self.wd_item -- a dict container
         of all the data content of the item.
-
-        :return: nothing
         """
         self.wd_item = {}
         self.wd_item["upload"] = True


### PR DESCRIPTION
Clean up docstrings by removing `return: nothing` which is useless and also indicating expected datatype in a cleaner way.

Task: https://phabricator.wikimedia.org/T165936